### PR TITLE
fix: 优化检查文件逻辑

### DIFF
--- a/src/Common/vendor/ztroubleshoot.cpp
+++ b/src/Common/vendor/ztroubleshoot.cpp
@@ -115,7 +115,6 @@ CheckDriver::CheckDriver(const QString &printerName, QObject *parent)
 bool CheckDriver::isPass()
 {
     QString strPPD;
-    QFile ppdFile;
     QStringList depends;
     PPD p;
     std::vector<Attribute> attrs;
@@ -128,8 +127,7 @@ bool CheckDriver::isPass()
     }
 
     strPPD = getPrinterPPD(m_printerName.toUtf8().data());
-    ppdFile.setFileName(strPPD);
-    if (!ppdFile.open(QFile::ReadOnly)) {
+    if (!QFile::exists(strPPD)) {
         qWarning() << strPPD << "not found";
         m_strMessage = tr("PPD file %1 not found").arg(strPPD);
         emit signalStateChanged(TStat_Fail, m_strMessage);


### PR DESCRIPTION
用 QFile::exists 函数替代 QFile::open 函数，减少文件打开操作