### PR TITLE
fix: risk function strcpy in snmp.c

### DIFF
--- a/src/cppcups/snmp.c
+++ b/src/cppcups/snmp.c
@@ -141,8 +141,13 @@ _cupsSNMPDefaultCommunity(void)
           if(!cupsstrcasecmp(line, "Community")){
               char* pValue = getValue(line);
 
-              if(pValue){
-                  strcpy(pRet, pValue);
+              if(pValue) {
+                  if (strlen(pValue) > sizeof(pRet)) {
+                      strcpy(pRet, "public");
+                  }
+                  else {
+                      strcpy(pRet, pValue);
+                  }
                   break;
               }
               else {


### PR DESCRIPTION
Log: Add length check before copying "pValue"