### PR TITLE
chore: hp color laserjet型号本地驱动查找型号修改

### DIFF
--- a/src/Common/vendor/zdrivermanager.cpp
+++ b/src/Common/vendor/zdrivermanager.cpp
@@ -880,6 +880,10 @@ int DriverSearcher::getLocalDrivers()
         return -3;
     }
 
+    if (strMake == "hp" && strModel.contains("colorlaserjet")) {
+        strModel.replace("colorlaserjet", "color laserjet");
+    }
+
     QList<QMap<QString, QVariant>> list = getExactMatchDrivers(strMake, strModel);
     if (!list.isEmpty()) {
         m_drivers += list;


### PR DESCRIPTION
    惠普color laserjet打印机本地已安装驱动未推荐，查找型号中未存在空格

Log: hp color laserjet打印机本地查找修改