### PR TITLE
fix: 默认打印机置灰问题

### DIFF
--- a/src/Printer/ui/dprintersshowwindow.cpp
+++ b/src/Printer/ui/dprintersshowwindow.cpp
@@ -1156,6 +1156,7 @@ void DPrintersShowWindow::printerListWidgetItemChangedSlot(const QModelIndex &pr
         bool isDefault = m_pPrinterManager->isDefaultPrinter(printerName);
         if (isDefault) {
             m_pDefaultPrinter->setChecked(true);
+            m_pDefaultPrinter->setEnabled(false);
         } else {
             m_pDefaultPrinter->setChecked(false);
         }


### PR DESCRIPTION
    设置默认打印机后，开启关闭设置，置灰状态被修改

Log: 默认打印机置灰问题
Bug: https://pms.uniontech.com/bug-view-260719.html