### PR TITLE
fix: 屏幕缩放设置按钮显示问题

### DIFF
--- a/src/Printer/ui/advancedsharewidget.cpp
+++ b/src/Printer/ui/advancedsharewidget.cpp
@@ -7,6 +7,7 @@
 #include <DGuiApplicationHelper>
 #include <DFontSizeManager>
 #include <DApplicationHelper>
+#include <DHiDPIHelper>
 
 #include <QHBoxLayout>
 #include <QPainter>
@@ -61,9 +62,9 @@ void AdvanceShareWidget::mouseReleaseEvent(QMouseEvent *event)
 void AdvanceShareWidget::updateIcon()
 {
     if (DGuiApplicationHelper::DarkType == DGuiApplicationHelper::instance()->themeType()) {
-        m_enterIcon->setPixmap(QPixmap(":/images/enter_details_normal.svg"));
+        m_enterIcon->setPixmap(DHiDPIHelper::loadNxPixmap(":/images/enter_details_normal.svg"));
     } else {
-        m_enterIcon->setPixmap(QPixmap(":/images/enter_details_normal-dark.svg"));
+        m_enterIcon->setPixmap(DHiDPIHelper::loadNxPixmap(":/images/enter_details_normal-dark.svg"));
     }
 
     update();


### PR DESCRIPTION
    屏幕缩放时，按钮显示模糊问题

Log: 设置屏幕缩放按钮显示模糊问题
Bug: https://pms.uniontech.com/bug-view-265183.html
Change-Id: I7260bf20c8d9e2f9264bb2ee6828d3f6ae6dad5f